### PR TITLE
Type fix for application statements/execution_file

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,6 @@ jobs:
       matrix:
         version:
           - '1'
-          - 'nightly'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           file: lcov.info
   test_build_project:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }} - build test
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,6 +40,7 @@ jobs:
           file: lcov.info
   test_build_project:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }} - build test
+    continue-on-error: ${{ matrix.nightly_build }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -51,6 +52,9 @@ jobs:
           - ubuntu-latest
         arch:
           - x64
+        include:
+          - version: nightly
+            nightly_build: true
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,6 +55,8 @@ jobs:
         nightly_build: [false]
         include:
           - version: nightly
+            os: ubuntu-latest
+            arch: x64
             nightly_build: true
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,6 +52,7 @@ jobs:
           - ubuntu-latest
         arch:
           - x64
+        nightly_build: [false]
         include:
           - version: nightly
             nightly_build: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,3 +38,42 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info
+  test_build_project:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        env:
+          TEST_BUILD_SYSIMG: "true"
+          TEST_BUILD_APP: "true"
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info
+

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 /Manifest.toml
 test/project/Manifest.toml
 test/project/deps
+test/project/build
 /docs/build/
 .vscode

--- a/src/build.jl
+++ b/src/build.jl
@@ -27,8 +27,8 @@ function build_sysimg(
         @info "cpu_target override to $cpu_target"
     end
 
-    exec_file = map(x -> pkgdir(m, x)::String, options.sysimg.precompile.execution_file)
-    stmt_file = map(x -> pkgdir(m, x)::String, options.sysimg.precompile.statements_file)
+    exec_file = String[pkgdir(m, x) for x in options.sysimg.precompile.execution_file]
+    stmt_file = String[pkgdir(m, x) for x in options.sysimg.precompile.statements_file]
 
     create_sysimage(
         nameof(m);
@@ -53,8 +53,8 @@ function build_application(m::Module, options::ComoniconOptions.Comonicon)
 
     @info "application options: " options.application
 
-    exec_file = map(x -> pkgdir(m, x)::String, options.application.precompile.execution_file)
-    stmt_file = map(x -> pkgdir(m, x)::String, options.application.precompile.statements_file)
+    exec_file = String[pkgdir(m, x) for x in options.application.precompile.execution_file]
+    stmt_file = String[pkgdir(m, x) for x in options.application.precompile.statements_file]
 
     create_app(
         pkgdir(m),

--- a/src/build.jl
+++ b/src/build.jl
@@ -178,9 +178,9 @@ end
 
 function tarball_name(m::Module, name::String; application::Bool = false)
     if application
-        return "$name-application-$(get_version(m))-$(osname())-$(Sys.ARCH).tar.gz"
+        return "$name-application-$(Comonicon.get_version(m))-$(osname())-$(Sys.ARCH).tar.gz"
     else
-        return "$name-sysimg-$(get_version(m))-julia-$VERSION-$(osname())-$(Sys.ARCH).tar.gz"
+        return "$name-sysimg-$(Comonicon.get_version(m))-julia-$VERSION-$(osname())-$(Sys.ARCH).tar.gz"
     end
 end
 

--- a/src/build.jl
+++ b/src/build.jl
@@ -53,8 +53,8 @@ function build_application(m::Module, options::ComoniconOptions.Comonicon)
 
     @info "application options: " options.application
 
-    exec_file = map(x -> pkgdir(m, x), options.application.precompile.execution_file)
-    stmt_file = map(x -> pkgdir(m, x), options.application.precompile.statements_file)
+    exec_file = map(x -> pkgdir(m, x)::String, options.application.precompile.execution_file)
+    stmt_file = map(x -> pkgdir(m, x)::String, options.application.precompile.statements_file)
 
     create_app(
         pkgdir(m),

--- a/test/project/Project.toml
+++ b/test/project/Project.toml
@@ -8,6 +8,7 @@ ComoniconBuilder = "0acea522-3a8c-4b93-9211-1fc67cbf95d9"
 ComoniconOptions = "a25bc8ac-9d24-42b2-8edd-3d267ec19fc5"
 ComoniconTestUtils = "53b67e40-53a7-4335-973f-e3e901fe4865"
 ComoniconTypes = "d0eb39ce-029e-40d1-add6-e32b3165f6a3"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
 julia = "1.6.1"

--- a/test/project/precompile_execution.jl
+++ b/test/project/precompile_execution.jl
@@ -1,0 +1,3 @@
+using TestProject
+
+println("In precompile execution file.")

--- a/test/project/test/runtests.jl
+++ b/test/project/test/runtests.jl
@@ -31,9 +31,49 @@ options = ComoniconOptions.Comonicon(
     install=ComoniconOptions.Install(
         path=usr_dir,
     ),
-    sysimg=ComoniconOptions.SysImg(;)
+    sysimg=ComoniconOptions.SysImg(precompile=ComoniconOptions.Precompile(["deps/precompile_execution.jl"], []))
 )
 
 # empty!(ARGS)
 # push!(ARGS, "sysimg")
 # install(TestProject, options)
+
+if get(ENV, "TEST_BUILD_SYSIMG", false) == "true"
+    @testset "System Image building" begin
+        options_sys = ComoniconOptions.Comonicon(
+            name="test",
+            install=ComoniconOptions.Install(
+                path=usr_dir,
+            ),
+        sysimg=ComoniconOptions.SysImg(precompile=ComoniconOptions.Precompile(["deps/precompile_execution.jl"], []))
+    )
+        outpath = ComoniconBuilder.pkgdir(TestProject, "deps/lib/libtest.so")
+        
+        isfile(outpath) && rm(outpath)
+        ComoniconBuilder.build_sysimg(TestProject, options_sys)
+        # Test if the new system image is present
+        @test isfile(outpath) && isnothing(rm(outpath))
+    end
+end
+
+if get(ENV, "TEST_BUILD_APP", false) == "true"
+    @testset "App building" begin
+        options_app = ComoniconOptions.Comonicon(
+            name="test",
+            install=ComoniconOptions.Install(
+                path=usr_dir,
+            ),
+        application=ComoniconOptions.Application(
+            precompile=ComoniconOptions.Precompile(["deps/precompile_execution.jl"], []),
+            incremental=true,
+            filter_stdlibs=false,
+            )
+    )
+        outpath = ComoniconBuilder.pkgdir(TestProject, "build/test/bin/test")
+
+        isfile(outpath) && rm(outpath)
+        ComoniconBuilder.build_application(TestProject, options_app)
+        # Test if the app has been built
+        @test isfile(outpath) && isnothing(rm(outpath))
+    end
+end

--- a/test/project/test/runtests.jl
+++ b/test/project/test/runtests.jl
@@ -45,7 +45,7 @@ if get(ENV, "TEST_BUILD_SYSIMG", false) == "true"
             install=ComoniconOptions.Install(
                 path=usr_dir,
             ),
-        sysimg=ComoniconOptions.SysImg(precompile=ComoniconOptions.Precompile(["deps/precompile_execution.jl"], []))
+        sysimg=ComoniconOptions.SysImg(precompile=ComoniconOptions.Precompile(["precompile_execution.jl"], []))
     )
         outpath = ComoniconBuilder.pkgdir(TestProject, "deps/lib/libtest.so")
         
@@ -64,7 +64,7 @@ if get(ENV, "TEST_BUILD_APP", false) == "true"
                 path=usr_dir,
             ),
         application=ComoniconOptions.Application(
-            precompile=ComoniconOptions.Precompile(["deps/precompile_execution.jl"], []),
+            precompile=ComoniconOptions.Precompile(["precompile_execution.jl"], []),
             incremental=true,
             filter_stdlibs=false,
             )


### PR DESCRIPTION
This is a great package for building CLI tools!

But, I have received this error when building an application  (on Julia 1.6.1): 

```
┌ Info: application options: 
│   options.application =
│    ComoniconOptions.Application(;
│        filter_stdlibs = false,
│        precompile = ComoniconOptions.Precompile(;
│            execution_file = ["test/runtest.jl"],
│        ),
└    )
ERROR: LoadError: TypeError: in keyword argument precompile_statements_file, expected Union{String, Vector{String}}, got a value of type Vector{Union{Nothing, String}}
Stacktrace:
 [1] build_application(m::Module, options::ComoniconOptions.Comonicon)
   @ ComoniconBuilder ~/.julia/packages/ComoniconBuilder/I9tvS/src/build.jl:59
 [2] install(m::Module, options::ComoniconOptions.Comonicon)
   @ ComoniconBuilder ~/.julia/packages/ComoniconBuilder/I9tvS/src/install.jl:66
 [3] #install#1
```


I think the problem is that the following lines:


https://github.com/comonicon/ComoniconBuilder.jl/blob/22e532e4636d2ac520633cef03634a7b33dff3d9/src/build.jl#L56-L58

results an Array that can contain `nothing`. The `nothing` element should be filtered out instead. It works about replacing them with:

The change in this PR should make sure the type is `Vector{String}` instead of `Vector{Union{Nothing, String}}` in the same way it is for the system image function. 

One more thing, if any of the files listed is missing the error would be raised inside the array comprehension. 
Perhaps it is better to explicitly check for the existence of nothing and warn its implication (e.g. one of the files do not exist) to the user? 

